### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -8,6 +8,10 @@ on:
             - "v[0-9]+.[0-9]+.[0-9]+*beta*"
         types: [opened, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
     check_pr:
         runs-on: ubuntu-latest

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
     check_pr:

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,9 +7,7 @@ on:
             - "v[0-9]+.[0-9]+.[0-9]+"
         types: [opened, edited, synchronize]
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
     lint_pr_title:

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,10 @@ on:
             - "v[0-9]+.[0-9]+.[0-9]+"
         types: [opened, edited, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
     lint_pr_title:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **2** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
